### PR TITLE
Represent Stream as a trait

### DIFF
--- a/p2p/src/conn.rs
+++ b/p2p/src/conn.rs
@@ -261,13 +261,14 @@ impl Tracker {
 /// Start listening on the provided connection and wraps it. Does not hang
 /// the current thread, instead just returns a future and the Connection
 /// itself.
-pub fn listen<H>(
-	stream: Stream,
+pub fn listen<S, H>(
+	stream: S,
 	version: ProtocolVersion,
 	tracker: Arc<Tracker>,
 	handler: H,
 ) -> io::Result<(ConnHandle, StopHandle)>
 where
+	S: Stream + 'static,
 	H: MessageHandler,
 {
 	let (send_tx, send_rx) = mpsc::sync_channel(SEND_CHANNEL_CAP);
@@ -289,8 +290,8 @@ where
 	))
 }
 
-fn poll<H>(
-	conn: Stream,
+fn poll<S, H>(
+	conn: S,
 	version: ProtocolVersion,
 	handler: H,
 	send_rx: mpsc::Receiver<Vec<u8>>,
@@ -298,6 +299,7 @@ fn poll<H>(
 	tracker: Arc<Tracker>,
 ) -> io::Result<JoinHandle<()>>
 where
+	S: Stream + 'static,
 	H: MessageHandler,
 {
 	// Split out tcp stream out into separate reader/writer halves.

--- a/p2p/src/handshake.rs
+++ b/p2p/src/handshake.rs
@@ -61,12 +61,12 @@ impl Handshake {
 		}
 	}
 
-	pub fn initiate(
+	pub fn initiate<S: Stream>(
 		&self,
 		capabilities: Capabilities,
 		total_difficulty: Difficulty,
 		self_addr: PeerAddr,
-		conn: &mut Stream,
+		conn: &mut S,
 	) -> Result<PeerInfo, Error> {
 		// prepare the first part of the handshake
 		let nonce = self.next_nonce();
@@ -124,16 +124,16 @@ impl Handshake {
 		Ok(peer_info)
 	}
 
-	pub fn accept(
+	pub fn accept<S: Stream>(
 		&self,
 		capab: Capabilities,
 		total_difficulty: Difficulty,
-		conn: &mut Stream,
+		mut conn: S,
 	) -> Result<PeerInfo, Error> {
 		// Note: We read the Hand message *before* we know which protocol version
 		// is supported by our peer (it is in the Hand message).
 		let version = ProtocolVersion::default();
-		let hand: Hand = read_message(conn, version, Type::Hand)?;
+		let hand: Hand = read_message(&mut conn, version, Type::Hand)?;
 
 		// all the reasons we could refuse this connection for
 		if hand.genesis != self.genesis {
@@ -144,7 +144,7 @@ impl Handshake {
 		} else {
 			// check the nonce to see if we are trying to connect to ourselves
 			let nonces = self.nonces.read();
-			let addr = resolve_peer_addr(hand.sender_addr.clone(), &conn);
+			let addr = resolve_peer_addr(hand.sender_addr.clone(), &mut conn);
 			if nonces.contains(&hand.nonce) {
 				// save ip addresses of ourselves
 				let mut addrs = self.addrs.write();
@@ -183,7 +183,7 @@ impl Handshake {
 			user_agent: USER_AGENT.to_string(),
 		};
 
-		write_message(conn, shake, Type::Shake)?;
+		write_message(&mut conn, shake, Type::Shake)?;
 		trace!("Success handshake with {}.", peer_info.addr);
 
 		// when more than one protocol version is supported, choosing should go here
@@ -204,7 +204,7 @@ impl Handshake {
 }
 
 /// Resolve the correct peer_addr based on the connection and the advertised port.
-fn resolve_peer_addr(advertised: PeerAddr, conn: &Stream) -> PeerAddr {
+fn resolve_peer_addr<S: Stream>(advertised: PeerAddr, conn: &S) -> PeerAddr {
 	match advertised {
 		PeerAddr::Socket(addr) => {
 			let port = addr.port();

--- a/p2p/tests/peer_handshake.rs
+++ b/p2p/tests/peer_handshake.rs
@@ -24,7 +24,7 @@ use std::{thread, time};
 
 use crate::core::core::hash::Hash;
 use crate::core::pow::Difficulty;
-use crate::p2p::types::{PeerAddr, Stream};
+use crate::p2p::types::PeerAddr;
 use crate::p2p::Peer;
 
 fn open_port() -> u16 {
@@ -68,7 +68,7 @@ fn peer_handshake() {
 	thread::sleep(time::Duration::from_secs(1));
 
 	let addr = SocketAddr::new(p2p_config.host, p2p_config.port);
-	let socket = Stream::Tcp(TcpStream::connect_timeout(&addr, time::Duration::from_secs(10)).unwrap());
+	let socket = TcpStream::connect_timeout(&addr, time::Duration::from_secs(10)).unwrap();
 
 	let my_addr = PeerAddr::from_socket_addr("127.0.0.1:5000".parse().unwrap());
 	let peer = Peer::connect(


### PR DESCRIPTION
We are interested only in behaviour of Stream, so it sounds right to
model it as a trait. It allows also reuse implementation of existing
traits (Read, Write) as is without wrapping. It simplifies client code
because it can work directly with TcpStream and I2pStream.

At the same time it brings some complexity - one more type parameter for
some functions and some boilerplate code to implement trait for
references.